### PR TITLE
fix(attempt): Inconsistent code block sizing on mobile

### DIFF
--- a/layouts/partials/custom_head.html
+++ b/layouts/partials/custom_head.html
@@ -2,3 +2,4 @@
 <script src="/js/topojson.v1.min.js"></script>
 <script src="/js/datamaps.world.min.js"></script>
 <link rel="stylesheet" href="/css/footer.css" />
+<link rel="stylesheet" href="/css/codeblock-fix.css" />

--- a/static/css/codeblock-fix.css
+++ b/static/css/codeblock-fix.css
@@ -1,0 +1,15 @@
+/* Fix variable-sized code blocks on mobile.
+   Constrains <pre> to viewport width and removes
+   conflicting white-space / text-wrap directives
+   from the hugo-bearcub theme's original.css. */
+
+pre {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+pre code {
+  white-space: pre;
+  text-wrap: unset;
+  overflow-x: unset;
+}


### PR DESCRIPTION
Add a custom CSS override (codeblock-fix.css) to constrain pre elements to viewport width and resolve conflicting white-space/text-wrap rules in the hugo-bearcub theme's original.css. This *should* fix that variable code block text size I've experienced on mobile.